### PR TITLE
`pll menu create` command, tests, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,51 @@ wp pll lang url <language-code>
 
 
 
+### wp pll menu
+
+Manage the WP Nav Menus.
+
+~~~
+wp pll menu 
+~~~
+
+
+
+
+
+
+
+### wp pll menu create
+
+Create a new menu for each language, AND assign it to a location.
+
+~~~
+wp pll menu create <menu-name> <location> [--porcelain]
+~~~
+
+**OPTIONS**
+
+	<menu-name>
+		A descriptive name for the menu.
+
+	<location>
+		Location’s slug.
+
+	[--porcelain]
+		Output just the new menu ids.
+
+**EXAMPLES**
+
+    $ wp pll menu create "Primary Menu" primary
+    Success: Assigned location to menu.
+    Success: Assigned location to menu.
+    Success: Assigned location to menu.
+
+    $ wp pll menu create "Secondary Menu" secondary --porcelain
+    21 22 23
+
+
+
 ### wp pll option
 
 Inspect and manage Polylang settings.

--- a/command.php
+++ b/command.php
@@ -42,15 +42,29 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
     require __DIR__ . '/src/Commands/Lang.php';
     require __DIR__ . '/src/Commands/PostType.php';
     require __DIR__ . '/src/Commands/Plugin.php';
+    require __DIR__ . '/src/Commands/Menu.php';
 
     WP_CLI::add_hook( 'before_wp_load', function() {
+
         WP_CLI::add_wp_hook( 'init', function() {
+
             # make sure polylang_mo post type is always registered
             if ( ! post_type_exists( 'polylang_mo' ) ) {
                 $labels = array( 'name' => __( 'Strings translations', 'polylang' ) );
                 register_post_type( 'polylang_mo', array( 'labels' => $labels, 'rewrite' => false, 'query_var' => false, '_pll' => true ) );
             }
+
         });
+
+    });
+
+    WP_CLI::add_hook( 'before_invoke:pll menu', function() {
+
+            # make sure localized (temporary) nav menu locations are always registered
+            require_once PLL_INC . '/nav-menu.php';
+            $pll_nav_menu = new \PLL_Nav_Menu( \PLL() );
+            $pll_nav_menu->create_nav_menu_locations();
+
     });
 
     // WP_CLI::add_command( 'pll',        Polylang_CLI\Cli::class );
@@ -60,6 +74,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
     WP_CLI::add_command( 'pll doctor',    Polylang_CLI\Commands\Doctor::class );
     WP_CLI::add_command( 'pll flag',      Polylang_CLI\Commands\Flag::class );
     WP_CLI::add_command( 'pll lang',      Polylang_CLI\Commands\Lang::class );
+    WP_CLI::add_command( 'pll menu',      Polylang_CLI\Commands\Menu::class );
     WP_CLI::add_command( 'pll option',    Polylang_CLI\Commands\Option::class );
     WP_CLI::add_command( 'pll post',      Polylang_CLI\Commands\Post::class );
     WP_CLI::add_command( 'pll post-type', Polylang_CLI\Commands\PostType::class );

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,8 @@
             "pll lang list",
             "pll lang update",
             "pll lang url",
+            "pll menu",
+            "pll menu create",
             "pll option",
             "pll option default",
             "pll option get",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "35d9446b31def11c7abbb5af5a3c401e",
+    "content-hash": "966aba7ecb06b69e53799dd3369cf71c",
     "packages": [
         {
             "name": "composer/ca-bundle",

--- a/features/menu.feature
+++ b/features/menu.feature
@@ -1,0 +1,22 @@
+@pll-menu
+Feature: Manage WordPress nav menus
+
+  Background:
+    Given a WP install
+    And I run `wp theme install twentysixteen --activate`
+    And I run `wp pll lang create Deutsch de de_DE`
+
+  Scenario: create nav menus and assign them to locations
+
+    When I run `wp pll menu create "Primary menu" primary`
+    Then STDOUT should contain:
+      """
+      Success: Assigned location to menu.
+      Success: Assigned location to menu.
+      """
+
+    When I run `wp pll menu create "Follow us!" social --porcelain`
+    Then STDOUT should contain:
+      """
+      11 12
+      """

--- a/src/Commands/Menu.php
+++ b/src/Commands/Menu.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Polylang_CLI\Commands;
+
+/**
+ * Manage the WP Nav Menus.
+ *
+ * @package Polylang_CLI
+ */
+class Menu extends BaseCommand {
+
+    /**
+	 * Create a new menu for each language, AND assign it to a location.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <menu-name>
+	 * : A descriptive name for the menu.
+	 *
+     * <location>
+	 * : Location’s slug.
+	 *
+	 * [--porcelain]
+	 * : Output just the new menu ids.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp pll menu create "Primary Menu" primary
+	 *     Success: Assigned location to menu.
+	 *     Success: Assigned location to menu.
+	 *     Success: Assigned location to menu.
+     *
+     *     $ wp pll menu create "Secondary Menu" secondary --porcelain
+	 *     21 22 23
+     *
+     * @when init
+	 */
+    public function create( $args, $assoc_args ) {
+
+        list( $menu_name, $location ) = $args;
+
+        $post_ids = $assigned = array();
+
+        $languages = wp_list_pluck( $this->pll->model->get_languages_list(), 'slug' );
+
+        foreach ( $languages as $slug ) {
+
+            ob_start();
+
+            $menu_name_i18n = ( $slug === $this->api->default_language() ) ? $menu_name : "$menu_name ($slug)";
+
+            $this->cli->command( array( 'menu', 'create', $menu_name_i18n ), array( 'porcelain' => true ) );
+
+            $post_id = ob_get_clean();
+
+            $location_i18n = ( $slug === $this->api->default_language() ) ? $location : "{$location}___{$slug}";
+
+            $this->cli->runcommand(
+                sprintf( 'menu location assign %d %s', $post_id, $location_i18n ),
+                array( 'return' => $this->cli->flag( $assoc_args, 'porcelain' ), 'launch' => false, 'exit_error' => false )
+            );
+
+            $post_ids[] = $post_id;
+        }
+
+        if ( $this->cli->flag( $assoc_args, 'porcelain' ) ) {
+            echo implode( ' ', array_map( 'absint', $post_ids ) );
+        }
+    }
+
+}


### PR DESCRIPTION
Create a new menu for each language, AND assign it to a location.

```
$ wp pll menu create "Primary Menu" primary
Success: Assigned location to menu.
Success: Assigned location to menu.
Success: Assigned location to menu.

$ wp pll menu create "Secondary Menu" secondary --porcelain
21 22 23
```