### PR TITLE
 Skip language test on trunk

### DIFF
--- a/features/lang.feature
+++ b/features/lang.feature
@@ -8,6 +8,7 @@ Feature: Manage Polylang languages
     And save STDOUT as {WP_VERSION}
 
   @core-language
+  @skip-trunk
   Scenario: Language CRUD commands
 
     When I run `wp pll lang create afrikaans af af`

--- a/features/lang.feature
+++ b/features/lang.feature
@@ -8,7 +8,6 @@ Feature: Manage Polylang languages
     And save STDOUT as {WP_VERSION}
 
   @core-language
-  @skip-trunk
   Scenario: Language CRUD commands
 
     When I run `wp pll lang create afrikaans af af`

--- a/utils/behat-tags.php
+++ b/utils/behat-tags.php
@@ -34,7 +34,9 @@ function version_tags( $prefix, $current, $operator = '<' ) {
 $wp_version_reqs = array();
 // Only apply @require-wp tags when WP_VERSION isn't 'latest' or 'nightly'
 // 'latest' and 'nightly' are expected to work with all features
-if ( ! in_array( getenv( 'WP_VERSION' ), array( 'latest', 'nightly', 'trunk' ), true ) ) {
+if ( in_array( getenv( 'WP_VERSION' ), array( 'latest', 'nightly', 'trunk' ), true ) ) {
+	$wp_version_reqs = array( '~@core-language' );
+} else {
 	$wp_version_reqs = version_tags( 'require-wp', getenv( 'WP_VERSION' ), '<' );
 }
 


### PR DESCRIPTION
Using the existing @core-language tag.

Fixes #68 